### PR TITLE
Possibility of passing custom parameters to i18next and a new way of working

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,18 @@ i18next-ko comes with exactly one new KnockoutJS binding: The `i18n` binding.
 
 You can use the binding in three different ways:
 
-1. Use a string:
+1. Use the tag content:
+   `<span data-bind="i18n">This sentence will be translated</span>`
+
+   It is automatically updated whenever the language is changed.
+
+2. Use a string:
    `data-bind="i18n: 'testTranslation'"` sets the content of the
    element to the translation with the key `testTranslation`.
 
    It is automatically updated whenever the language is changed.
 
-2. Use a key and add variables:
+3. Use a key and add variables:
    `data-bind="i18n: { key: 'greeting', options: { name: name } }"`
    sets the content of the element to the translation with the given key.
 
@@ -84,7 +89,7 @@ You can use the binding in three different ways:
    It is automatically updated whenever the language is changed or the value of
    any observable variable is changed.
 
-3. Mix both approaches and bind multiple attributes:
+4. Mix both approaches and bind multiple attributes:
    `data-bind="i18n: { 'html': 'testTranslation', 'title': { key: 'greeting',
    options: { name: name } } }"` sets the content of the element to the
    translation with the key `testTranslation`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage
 Initialization
 --------------
 To initialize i18next-ko, you need to call `i18nextko.init()`. It takes the
-following parameters: `i18nextko.init(resourceStore, language, ko)`.
+following parameters: `i18nextko.init(resourceStore, language, ko, jquery, i18next_settings)`.
 
 * The `resourceStore` is a i18next resource store. It looks like this:
 ```
@@ -54,6 +54,10 @@ following parameters: `i18nextko.init(resourceStore, language, ko)`.
   it may solve some issues if you use Browserify and have some dependencies that
   require different versions of KnockoutJS.
   Defaults to `window.ko`.
+* You may set `jquery` to your jquery object. Defaults to `window.$`.
+* The `i18next_settings` is an object containing extra custom settings to be sent to i18next.
+  For example, to use Key based fallback, you should use `{nsSeparator: false, keySeparator: false}`.
+  Defaults to no extra settings.
 
 Note that the i18nextko object basically is a singleton. Once you initialized
 it, the translations and the `i18n` binding will be available everywhere.

--- a/src/i18next-ko.js
+++ b/src/i18next-ko.js
@@ -55,7 +55,7 @@
     _koCallbacks: [],
 
     setLanguage: function (language) {
-      i18n.setLng(language);
+      i18n.changeLanguage(language);
       i18nextko._language(language);
       i18nextko._koCallbacks.forEach(function (c) {
         return c.call(undefined);
@@ -65,15 +65,15 @@
       }
     },
 
-    init: function (resourceStore, language, knockout, jquery) {
+    init: function (resourceStore, language, knockout, jquery, i18next_settings) {
       ko = knockout || window.ko;
       $ = jquery || window.$;
 
-      i18n.init({
-        compatibilityAPI: 'v1',
-        lng: language || 'en',
-        resStore: resourceStore
-      });
+      settings = i18next_settings || {}
+      settings.lng = language || 'en'
+      settings.resources = language || 'en'
+
+      i18n.init(settings);
 
       ko.bindingHandlers['i18n'] = koBindingHandler;
       i18nextko._language = ko.observable(language);

--- a/src/i18next-ko.js
+++ b/src/i18next-ko.js
@@ -71,7 +71,7 @@
 
       settings = i18next_settings || {}
       settings.lng = language || 'en'
-      settings.resources = language || 'en'
+      settings.resources = resourceStore
 
       i18n.init(settings);
 

--- a/src/i18next-ko.js
+++ b/src/i18next-ko.js
@@ -1,3 +1,11 @@
+/*
+
+https://github.com/leMaik/i18next-ko/
+Usage Examples:
+<span data-bind="i18n">This sentence should be translated.</span>
+<span data-bind="i18n: 'This sentence should be translated.'"></span>
+<span data-bind="i18n: { key: '{{ who }} are {{ what }}', options: { who: 'Translations', what: 'fun' } }"></span>
+*/
 (function () {
   var i18n;
   if (typeof require !== 'undefined') {
@@ -23,6 +31,9 @@
 
     update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
       var value = ko.toJS(valueAccessor());
+      if(value === undefined){
+        value = element.innerText.trim();
+      }
       if (typeof value === 'string') {
         element.innerHTML = i18n.t(value);
       } else if (value.key) {


### PR DESCRIPTION
Hi!
I need to use Key based fallback (http://i18next.com/translate/keyBasedFallback/) and in order to do so I needed to pass some parameters to i18next.

This patch allows one to do that.
There is one little problem: I had to stop using compatibilityAPI: 'v1',
That means, even if one does not send any extra parameters to i18next-ko, if `this_key_does_not_exist` is not there, it will now show 

`this_key_does_not_exist` instead of `translate:this_key_does_not_exist`

Which may or may not be a problem for your users.
